### PR TITLE
fix(task_scheduler): possible int overflow, casting int32/64 to uint16.

### DIFF
--- a/delivery/websocket/task_scheduler.go
+++ b/delivery/websocket/task_scheduler.go
@@ -35,13 +35,13 @@ func (s *Server) checkExpiration() { //nolint
 					continue
 				}
 
-				kind, err := strconv.Atoi(data[1])
+				kind, err := strconv.ParseUint(data[1], 10, 16)
 				if err != nil {
 					continue
 				}
 
 				if err := s.handler.DeleteByID(data[0],
-					types.Kind(kind)); err != nil { //nolint
+					types.Kind(kind)); err != nil {
 					failedTasks = append(failedTasks, task)
 				}
 			}

--- a/delivery/websocket/task_scheduler.go
+++ b/delivery/websocket/task_scheduler.go
@@ -40,7 +40,7 @@ func (s *Server) checkExpiration() { //nolint
 					continue
 				}
 
-				// lint error is g115 gosec rule. this rule is broken. 
+				// lint error is g115 gosec rule. this rule is broken.
 				// see: https://github.com/securego/gosec/issues/1288
 				if err := s.handler.DeleteByID(data[0],
 					types.Kind(kind)); err != nil { //nolint

--- a/delivery/websocket/task_scheduler.go
+++ b/delivery/websocket/task_scheduler.go
@@ -40,8 +40,10 @@ func (s *Server) checkExpiration() { //nolint
 					continue
 				}
 
+				// lint error is g115 gosec rule. this rule is broken. 
+				// see: https://github.com/securego/gosec/issues/1288
 				if err := s.handler.DeleteByID(data[0],
-					types.Kind(kind)); err != nil {
+					types.Kind(kind)); err != nil { //nolint
 					failedTasks = append(failedTasks, task)
 				}
 			}


### PR DESCRIPTION
## Description

fixes: https://github.com/dezh-tech/immortal/security/code-scanning/2

## Related Issue

- Fixes #111