### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   linting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/dezh-tech/immortal/security/code-scanning/3](https://github.com/dezh-tech/immortal/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since this workflow only performs linting and formatting checks, it does not require write permissions. The minimal required permission is `contents: read`, which allows the workflow to read the repository contents. This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
