### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/dezh-tech/immortal/security/code-scanning/4](https://github.com/dezh-tech/immortal/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only checks out code and runs tests, it does not require write permissions. The minimal required permission is `contents: read`, which allows the workflow to read the repository contents. This change ensures the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
