### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,5 +1,8 @@
 name: Semantic PR
 
+permissions:
+  contents: read
+
 on:
   pull_request_target:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/dezh-tech/immortal/security/code-scanning/5](https://github.com/dezh-tech/immortal/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow's purpose is to validate PR titles, it likely only requires `contents: read` permissions. This will restrict the `GITHUB_TOKEN` to the least privilege necessary for the workflow to function correctly. The `permissions` block will be added at the root level of the workflow, applying to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
